### PR TITLE
FIX :: JWT Strategy Bearer토큰 먹도록 변경

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,10 +1,16 @@
 import { Module } from '@nestjs/common';
 import { UserModule } from './user/user.module';
 import { AuthModule } from './auth/auth.module';
+import { PassportModule } from '@nestjs/passport';
+import { JwtStrategy } from './auth/jwt.strategy';
 
 @Module({
-  imports: [UserModule, AuthModule],
+  imports: [
+    UserModule,
+    AuthModule,
+    PassportModule.register({ defaultStrategy: 'jwt' }),
+  ],
   controllers: [],
-  providers: [],
+  providers: [JwtStrategy],
 })
 export class AppModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,7 +1,16 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import * as dotenv from 'dotenv';
+dotenv.config();
+import {
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { TokenPayload } from './tokenPayload.interface';
 import { UserService } from 'src/user/user.service';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
 
 @Injectable()
 export class AuthService {
@@ -19,11 +28,13 @@ export class AuthService {
     return token;
   }
 
-  validateUser(payload: any) {
-    const user = this.userService.findOne(payload.uid);
-    if (user) {
-      return user;
-    }
-    throw new NotFoundException();
+  async validateUser(token: any) {
+    console.log(token.uid);
+    const userInfo = await prisma.user.findUnique({
+      select: { id: true },
+      where: { uid: token.uid },
+    });
+    if (!userInfo) throw new UnauthorizedException();
+    return userInfo;
   }
 }

--- a/src/user/dto/update-user.dto.ts
+++ b/src/user/dto/update-user.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateUserDto } from './create-user.dto';
-
-export class UpdateUserDto extends PartialType(CreateUserDto) {}
+export class UpdateUserDto {
+  id: string;
+  nickname: string;
+}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,8 +1,22 @@
-import { Controller, Get, Post, Body, Param, HttpCode } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  HttpCode,
+  Put,
+  Headers,
+  UseGuards,
+  Res,
+  HttpStatus,
+} from '@nestjs/common';
 import { UserService } from './user.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { LoginUserDto } from './dto/login-user-dto';
 import { AuthService } from '@/auth/auth.service';
+import { UpdateUserDto } from './dto/update-user.dto';
+import { AuthGuard } from '@nestjs/passport';
 
 @Controller('api/user')
 export class UserController {
@@ -22,7 +36,6 @@ export class UserController {
     const authorize = await this.userService.login(loginUserDto);
     const token = this.authService.getJwtToken(authorize);
 
-    console.log(token);
     return { token };
   }
 
@@ -31,10 +44,16 @@ export class UserController {
     return this.userService.findOne(+uid);
   }
 
-  // @Patch(':id')
-  // update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) { // 프론트랑 상의 후 개발
-  //   return this.userService.update(+id, updateUserDto);
-  // }
+  @Put(':uid')
+  @UseGuards(AuthGuard('jwt'))
+  update(
+    @Param('uid') uid: string,
+    @Headers('Authorization') authorizationHeader: string,
+    @Body() updateUserDto: UpdateUserDto,
+  ) {
+    this.userService.update(+uid, updateUserDto);
+    return HttpStatus.OK;
+  }
 
   // @Delete(':id')
   // remove(@Param('id') id: string) {   // 프론트랑 상의 후 개발

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -9,12 +9,14 @@ import { UpdateUserDto } from './dto/update-user.dto';
 import { PrismaClient } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
 import { LoginUserDto } from './dto/login-user-dto';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
 
 const prisma = new PrismaClient();
 
 @Injectable()
 export class UserService {
-  // constructor(private readonly authService: AuthService) {}
+  //constructor(private readonly authService: AuthService) {}
 
   async create(createUserDto: CreateUserDto) {
     const { id, nickname } = createUserDto;
@@ -42,22 +44,24 @@ export class UserService {
     const pwdCompare = await bcrypt.compare(pwd, userInfo[0].pwd);
 
     if (pwdCompare) {
-      const payload = { id: userInfo[0].id, nickname: userInfo[0].nickname };
+      //  const payload = { id: userInfo[0].id, nickname: userInfo[0].nickname };
       return userInfo[0].uid;
     }
     throw new UnauthorizedException();
   }
 
   async findOne(uid: number) {
-    return await prisma.user.findUnique({
+    const userInfo = await prisma.user.findUnique({
       select: { id: true, nickname: true },
       where: { uid },
     });
+    if (!userInfo) throw new NotFoundException();
+    return userInfo;
   }
 
-  // update(id: number, updateUserDto: UpdateUserDto) {
-  //   return `This action updates a #${id} user`;
-  // }
+  async update(uid: number, updateUserDto: UpdateUserDto) {
+    return await prisma.user.update({ where: { uid }, data: updateUserDto });
+  }
 
   // remove(id: number) {
   //   return `This action removes a #${id} user`;


### PR DESCRIPTION
JWT 전략을 설정했는데 bearer 토큰을 안 먹어서 먹도록 바꿨습니다.
앞으로 토큰이 필요한 코드는 데코레이터 위에   @UseGuards(AuthGuard('jwt')) 사용하시면 알아서 필터링 됩니다.

```js
  @Put(':uid')
  @UseGuards(AuthGuard('jwt')) // 전략 적용
  update(
    @Param('uid') uid: string,
    @Headers('Authorization') authorizationHeader: string,
    @Body() updateUserDto: UpdateUserDto,
  ) {
    this.userService.update(+uid, updateUserDto);
    return HttpStatus.OK;
  }
```
예시입니다.